### PR TITLE
Add GHCR publish workflow

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,54 @@
+name: publish-ghcr
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - ".github/workflows/publish-ghcr.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.actor }}/comfyui
+  COMFYUI_TAG: v0.8.2
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ env.COMFYUI_TAG }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.COMFYUI_TAG }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - `certs/`: TLS certificate assets (self-signed workflow in README).
 - `test/container-structure-test.yaml`: Container structure test configuration.
 - `.github/workflows/container-structure-test.yml`: CI workflow for image build + structure tests.
+- `.github/workflows/publish-ghcr.yml`: CI workflow for GHCR image publish.
 
 ## Local workflows
 - Build and run:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ docker compose up --build
 
 - https://localhost:8188
 
+## Container Registry (GHCR)
+
+Public images are published to GHCR via GitHub Actions.
+
+- Image: `ghcr.io/a2c-j1/comfyui`
+- Tags: `latest`, `v0.8.2`
+
+Example:
+
+```bash
+docker pull ghcr.io/a2c-j1/comfyui:latest
+```
+
 ## TLS Configuration
 
 ComfyUI reads TLS key/cert paths from environment variables:

--- a/README_jp.md
+++ b/README_jp.md
@@ -57,6 +57,19 @@ docker compose up --build
 
 - https://localhost:8188
 
+## Container Registry (GHCR)
+
+GitHub Actions で GHCR に public イメージを公開しています。
+
+- イメージ: `ghcr.io/a2c-j1/comfyui`
+- タグ: `latest`, `v0.8.2`
+
+例:
+
+```bash
+docker pull ghcr.io/a2c-j1/comfyui:latest
+```
+
 ## TLS 設定
 
 ComfyUI は以下の環境変数で証明書を参照します。

--- a/compose.yml.example
+++ b/compose.yml.example
@@ -1,6 +1,7 @@
 services:
   comfyui:
-    build: .
+    image: ghcr.io/a2c-j1/comfyui:latest
+    # build: .
     container_name: comfyui
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary
- add GHCR publish workflow for public image
- document GHCR usage and update compose example
- record publish workflow in AGENTS

## Testing
- not run (docs/workflow changes)