### PR TITLE
Update ComfyUI to v0.10.0 and correct environment variable name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git \
     && cd /app/ComfyUI \
-    && git fetch --depth 1 origin tag v0.9.1 \
-    && git checkout v0.9.1
+    && git fetch --depth 1 origin tag v0.10.0 \
+    && git checkout v0.10.0
 WORKDIR /app/ComfyUI
 RUN python -m pip install --no-cache-dir -r requirements.txt \
     && python -m pip install --no-cache-dir -r manager_requirements.txt \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo provides a Docker setup for running ComfyUI with optional TLS.
 
 ## Enabled Features (This Image)
 
-- ComfyUI `v0.9.1` (pinned release tag)
+- ComfyUI `v0.10.0` (pinned release tag)
 - ComfyUI Manager enabled (`--enable-manager`)
 - CUDA-enabled PyTorch runtime (PyTorch 2.9.1 + CUDA 13.0; NVIDIA GPU required for GPU acceleration)
 - Optional HTTPS/TLS if `TLS_KEYFILE` and `TLS_CERTFILE` are provided
@@ -63,7 +63,7 @@ docker compose up --build
 Public images are published to GHCR.
 
 - Image: `ghcr.io/a2c-j1/comfyui`
-- Tags: `latest`, `v0.9.1`
+- Tags: `latest`, `v0.10.0`
 
 Example:
 
@@ -154,7 +154,7 @@ Inputs go in `./data/input`, and outputs are saved to `./data/output`.
 ## Notes
 
 - If you want HTTPS, generate certs into `./certs` before starting.
-- The Dockerfile pins ComfyUI to the `v0.9.1` release tag.
+- The Dockerfile pins ComfyUI to the `v0.10.0` release tag.
 - The base image uses PyTorch 2.9.1 with CUDA 13.0 (cudnn9 runtime).
 - Verified only on Ubuntu Desktop 24.04 with an RTX 5070.
 - WSL2 has not been tested.

--- a/README_jp.md
+++ b/README_jp.md
@@ -13,7 +13,7 @@
 
 ## このイメージで有効になる機能
 
-- ComfyUI `v0.9.1`（リリースタグ固定）
+- ComfyUI `v0.10.0`（リリースタグ固定）
 - ComfyUI Manager を有効化（`--enable-manager`）
 - CUDA 対応 PyTorch ランタイム（PyTorch 2.9.1 + CUDA 13.0。GPU 利用には NVIDIA GPU が必要）
 - `TLS_KEYFILE` / `TLS_CERTFILE` があれば HTTPS/TLS を有効化
@@ -62,7 +62,7 @@ docker compose up --build
 GHCR に public イメージを公開しています。
 
 - イメージ: `ghcr.io/a2c-j1/comfyui`
-- タグ: `latest`, `v0.9.1`
+- タグ: `latest`, `v0.10.0`
 
 例:
 
@@ -151,7 +151,7 @@ ComfyUI の想定構成に合わせて `./data/models` 配下へ配置してく�
 ## 注意点
 
 - HTTPS を使う場合は起動前に `./certs` に証明書を用意してください。
-- Dockerfile は ComfyUI のリリースタグ `v0.9.1` に固定しています。
+- Dockerfile は ComfyUI のリリースタグ `v0.10.0` に固定しています。
 - ベースイメージは PyTorch 2.9.1 + CUDA 13.0（cudnn9 runtime）です。
 - 動作検証は Ubuntu Desktop 24.04 + RTX-5070 のみで行っています。
 - WSL2 での動作検証は行っていません。

--- a/compose.yml.example
+++ b/compose.yml.example
@@ -1,12 +1,14 @@
 services:
   comfyui:
-    image: ghcr.io/a2c-j1/comfyui:v0.9.1
+    image: ghcr.io/a2c-j1/comfyui:v0.10.0
     # build: .
     container_name: comfyui
     restart: unless-stopped
 
     ports:
       - "8188:8188"
+
+    gpus: all
 
     environment:
       - TLS_KEYFILE=/app/ComfyUI/certs/key.pem
@@ -22,6 +24,7 @@ services:
       - ./data/__manager/config.ini:/app/ComfyUI/user/__manager/config.ini
       - ./certs:/app/ComfyUI/certs
 
+    # Swarm-only GPU reservation; ignored by docker compose.
     deploy:
       resources:
         reservations:

--- a/scripts/push_ghcr.py
+++ b/scripts/push_ghcr.py
@@ -6,7 +6,7 @@ import sys
 
 OWNER = "a2c-j1"
 IMAGE = "comfyui"
-DEFAULT_TAGS = ["latest", "v0.9.1"]
+DEFAULT_TAGS = ["latest", "v0.10.0"]
 
 
 def run(cmd: list[str]) -> None:
@@ -15,7 +15,7 @@ def run(cmd: list[str]) -> None:
 
 
 def main() -> int:
-    token = os.environ.get("GHCR_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN")
     if not token:
         token = getpass.getpass("GHCR PAT (write:packages): ")
 

--- a/test/container-structure-test.yaml
+++ b/test/container-structure-test.yaml
@@ -54,10 +54,10 @@ commandTests:
   - name: "toml is installed"
     command: "python"
     args: ["-c", "import toml; print(toml.__version__)"]
-  - name: "ComfyUI tag is v0.9.1"
+  - name: "ComfyUI tag is v0.10.0"
     command: "git"
     args: ["-C", "/app/ComfyUI", "describe", "--tags", "--exact-match"]
-    expectedOutput: ["v0.9.1"]
+    expectedOutput: ["v0.10.0"]
   - name: "PyTorch is 2.9.1 with CUDA 13.0"
     command: "python"
     args:


### PR DESCRIPTION
Correct the environment variable name to `GITHUB_TOKEN` and update ComfyUI to version 0.10.0 in the Dockerfile, README, and configuration files. This ensures compatibility with the latest features and improvements.