### PR TITLE
[codex] Improve Docker build caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - 複数エージェントで作業する場合、親エージェントはナビゲーターとして改善方針・制約・レビューを担当し、サブエージェントはドライバーとして worktree 内で実装・検証を担当する。
 - サブエージェントへ依頼する際は、対象 worktree、変更してよいファイル、使ってよい Docker tag、運用中環境へ触れない条件を明示する。
 - イメージビルド検証では、運用中の tag / container / compose service を上書きしない別 tag を使う。
+- ビルド時間改善の検証は `docker build -t comfyui-docker:<検証用tag> .` のようにイメージビルドだけで行い、`docker compose up` など運用中サービスに影響しうる起動操作は行わない。
 - `Dockerfile` を更新したら以下を合わせて更新する:
   - `README.md` / `README_jp.md` の説明
   - `test/container-structure-test.yaml` のバージョン検証

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,50 @@
 # syntax=docker/dockerfile:1.4
 FROM pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libgl1 \
+    libglib2.0-0
+
+RUN groupadd -g 1000 appuser \
+    && useradd -m -u 1000 -g 1000 appuser \
+    && mkdir -p /app \
+    && chown appuser:appuser /app
+
 # Install ComfyUI
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git \
-    && cd /app/ComfyUI \
-    && git fetch --depth 1 origin tag v0.24.0\
-    && git checkout v0.24.0
+USER appuser
+RUN git clone --depth 1 --branch v0.24.0 https://github.com/comfyanonymous/ComfyUI.git
+USER root
 WORKDIR /app/ComfyUI
-RUN python -m pip install --no-cache-dir -r requirements.txt \
-    && python -m pip install --no-cache-dir -r manager_requirements.txt \
-    && python -m pip install --no-cache-dir uv GitPython toml \
-    && python -m pip install --no-cache-dir  matrix-nio
-
-    
-RUN apt update && apt install -y libgl1 libglib2.0-0
-
-RUN apt install -y build-essential \
-    && export CC=/usr/bin/gcc \
-    && export CXX=/usr/bin/g++
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install -r requirements.txt \
+    && python -m pip install -r manager_requirements.txt \
+    && python -m pip install uv GitPython toml \
+    && python -m pip install matrix-nio
 
 RUN --mount=type=bind,source=data/custom_nodes,target=/tmp/custom_nodes,readonly \
-    find /tmp/custom_nodes -mindepth 2 -maxdepth 2 \
+    --mount=type=cache,target=/root/.cache/pip \
+    export CC=/usr/bin/gcc \
+    && export CXX=/usr/bin/g++ \
+    && find /tmp/custom_nodes -mindepth 2 -maxdepth 2 \
         \( -iname 'requirements*.txt' -o -iname 'requirement*.txt' \) \
         -not -path '*/.disabled/*' -print0 \
     | sort -z \
-    | xargs -0 -r -n 1 python -m pip install --no-cache-dir -r
+    | xargs -0 -r -n 1 python -m pip install -r
 
 
 # Create entrypoint script for optional TLS support
 WORKDIR /app
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-
-# Create a non-root user to run the application
-RUN groupadd -g 1000 appuser && \
-    useradd -m -u 1000 -g 1000 appuser && \
-    chown -R appuser:appuser /app && \
-    chown -R 1000:1000 /opt/conda
+COPY --chown=appuser:appuser --chmod=755 entrypoint.sh /app/entrypoint.sh
+ENV PIP_USER=1 \
+    PYTHONUSERBASE=/home/appuser/.local \
+    PATH=/home/appuser/.local/bin:$PATH
 USER appuser
 
 EXPOSE 8188

--- a/README.md
+++ b/README.md
@@ -133,10 +133,13 @@ Host directories are mounted into the container:
 
 - `./data/custom_nodes`
 - `./data/user`
+- `./data/__manager`
 - `./data/models`
 - `./data/input`
 - `./data/output`
 - `./certs`
+
+If an existing installation has ComfyUI Manager config, snapshots, or cache under `./data/user/__manager`, move the files you need to `./data/__manager`.
 
 ## Model & Data Placement Examples
 

--- a/README_jp.md
+++ b/README_jp.md
@@ -130,10 +130,13 @@ certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "comfyui-local" -i ./certs/cert.
 
 - `./data/custom_nodes`
 - `./data/user`
+- `./data/__manager`
 - `./data/models`
 - `./data/input`
 - `./data/output`
 - `./certs`
+
+既存環境で ComfyUI Manager の config、snapshots、cache が `./data/user/__manager` にある場合は、必要に応じて `./data/__manager` へ移行してください。
 
 ## データ配置の例（モデル置き場）
 

--- a/compose.yml.example
+++ b/compose.yml.example
@@ -21,7 +21,7 @@ services:
       - ./data/models:/app/ComfyUI/models
       - ./data/input:/app/ComfyUI/input
       - ./data/output:/app/ComfyUI/output
-      - ./data/__manager/config.ini:/app/ComfyUI/user/__manager/config.ini
+      - ./data/__manager:/app/ComfyUI/user/__manager
       - ./certs:/app/ComfyUI/certs
 
     # Swarm-only GPU reservation; ignored by docker compose.


### PR DESCRIPTION
## Summary
- Rework the Dockerfile to use BuildKit cache mounts for apt and pip installs.
- Avoid the expensive recursive `/opt/conda` chown by creating `appuser` earlier and only owning `/app`.
- Update the example Compose manager mount from a single `config.ini` file bind to the `data/__manager` directory so ComfyUI Manager can create runtime files as a non-root user.
- Document the build-time validation rule in `AGENTS.md`.

## Validation
- `docker build --progress=plain -t comfyui-docker:build-cache-driver-test .` succeeded.
- Isolated Compose smoke test with project `comfyui-build-time-test`, container `comfyui-build-time-test`, image `comfyui-docker:build-time-test`, and port `8190:8188` succeeded.
- Cached Compose build completed in `real 3.20s`; all Dockerfile steps were cached.
- Smoke startup reached HTTP `200` on `http://127.0.0.1:8190/` in `11s`.
- Test container/network and generated manager cache files were cleaned up.

## Notes
- The smoke test only checked startup and the top page HTTP response. It did not run an end-to-end ComfyUI workflow or ComfyUI Manager update flow.
- `/opt/conda` remains root-owned. Runtime package installs should go to the configured user site via `PIP_USER=1`.